### PR TITLE
SystemRules 라이브러리 Error 처리

### DIFF
--- a/Chapter_02/stereo-autoconfig/gradle.properties
+++ b/Chapter_02/stereo-autoconfig/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_02/stereo-autoconfig/src/test/java/soundsystem/CDPlayerTest.java
+++ b/Chapter_02/stereo-autoconfig/src/test/java/soundsystem/CDPlayerTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-autoconfig/src/test/java/soundsystem/CDPlayerXMLConfigTest.java
+++ b/Chapter_02/stereo-autoconfig/src/test/java/soundsystem/CDPlayerXMLConfigTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-javaconfig/gradle.properties
+++ b/Chapter_02/stereo-javaconfig/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_02/stereo-javaconfig/src/test/java/soundsystem/CDPlayerTest.java
+++ b/Chapter_02/stereo-javaconfig/src/test/java/soundsystem/CDPlayerTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-mixedconfig/gradle.properties
+++ b/Chapter_02/stereo-mixedconfig/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_02/stereo-mixedconfig/src/test/java/soundsystem/ImportJavaConfigTest.java
+++ b/Chapter_02/stereo-mixedconfig/src/test/java/soundsystem/ImportJavaConfigTest.java
@@ -1,10 +1,10 @@
 package soundsystem;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-mixedconfig/src/test/java/soundsystem/ImportXmlConfigTest.java
+++ b/Chapter_02/stereo-mixedconfig/src/test/java/soundsystem/ImportXmlConfigTest.java
@@ -1,10 +1,10 @@
 package soundsystem;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-xmlconfig/gradle.properties
+++ b/Chapter_02/stereo-xmlconfig/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/CNamespaceReferenceTest.java
+++ b/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/CNamespaceReferenceTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/CNamespaceValueTest.java
+++ b/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/CNamespaceValueTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/ConstructorArgCollectionTest.java
+++ b/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/ConstructorArgCollectionTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/ConstructorArgReferenceTest.java
+++ b/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/ConstructorArgReferenceTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/ConstructorArgValueTest.java
+++ b/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/ConstructorArgValueTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/PNamespaceRefTest.java
+++ b/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/PNamespaceRefTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/PNamespaceValueTest.java
+++ b/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/PNamespaceValueTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/PNamespaceWithUtilNamespaceTest.java
+++ b/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/PNamespaceWithUtilNamespaceTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/PropertyRefTest.java
+++ b/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/PropertyRefTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/PropertyValueTest.java
+++ b/Chapter_02/stereo-xmlconfig/src/test/java/soundsystem/PropertyValueTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;


### PR DESCRIPTION
# SystemOutRule 코드 에러

## Issue : 
 * SystemOutRule 관련 에러 (import도 안되고, 1.16버전에서 정상화 되는 것 확인했습니다.)
```java
@Rule
  public final SystemOutRule log = new SystemOutRule().enableLog();
```
## Solved:
 * SystemRules 관련 라이브러리 버전을 올렸습니다. 
 * SystemRules Library version 1.5.0 -> 1.16.0