### PR TITLE
SystemRules Library version 동일 적용

### DIFF
--- a/Chapter_01/knight/gradle.properties
+++ b/Chapter_01/knight/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_03/conditional/gradle.properties
+++ b/Chapter_03/conditional/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_03/externals/gradle.properties
+++ b/Chapter_03/externals/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_03/profiles/gradle.properties
+++ b/Chapter_03/profiles/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_03/scopedbeans/gradle.properties
+++ b/Chapter_03/scopedbeans/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_05/Spittr/gradle.properties
+++ b/Chapter_05/Spittr/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_06/jsp/gradle.properties
+++ b/Chapter_06/jsp/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_06/thymeleaf/gradle.properties
+++ b/Chapter_06/thymeleaf/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_06/tiles/gradle.properties
+++ b/Chapter_06/tiles/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_07/Spittr/gradle.properties
+++ b/Chapter_07/Spittr/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_08/SpringPizza/gradle.properties
+++ b/Chapter_08/SpringPizza/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_09/thymeleaf/gradle.properties
+++ b/Chapter_09/thymeleaf/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_10/jdbc/gradle.properties
+++ b/Chapter_10/jdbc/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_11/hibernate4/gradle.properties
+++ b/Chapter_11/hibernate4/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_11/jpa-hibernate/gradle.properties
+++ b/Chapter_11/jpa-hibernate/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_11/jpa-springdata/gradle.properties
+++ b/Chapter_11/jpa-springdata/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_12/mongo/gradle.properties
+++ b/Chapter_12/mongo/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_13/caching/gradle.properties
+++ b/Chapter_13/caching/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_14/methodsecurity/gradle.properties
+++ b/Chapter_14/methodsecurity/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_16/spitter-api-content-negotiation/gradle.properties
+++ b/Chapter_16/spitter-api-content-negotiation/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_16/spitter-api-message-converters/gradle.properties
+++ b/Chapter_16/spitter-api-message-converters/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_17/amqp/gradle.properties
+++ b/Chapter_17/amqp/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_17/jms/gradle.properties
+++ b/Chapter_17/jms/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_18/STOMP/gradle.properties
+++ b/Chapter_18/STOMP/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_18/STOMPUser/gradle.properties
+++ b/Chapter_18/STOMPUser/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_18/WebSocket/gradle.properties
+++ b/Chapter_18/WebSocket/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/Chapter_19/mail/gradle.properties
+++ b/Chapter_19/mail/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,6 @@ springDataJpaVersion=1.3.2.RELEASE
 springSecurityVersion = 3.2.0.RELEASE
 springVersion=4.0.7.RELEASE
 springWebflowVersion=2.4.1.RELEASE
-systemRulesVersion=1.5.0
+systemRulesVersion=1.16.0
 thymeleafVersion = 2.1.3.RELEASE
 tilesVersion = 3.0.1


### PR DESCRIPTION
# [SystemRules 라이브러리 Error 처리 PR에 연장선](https://github.com/Jpub/SpringInAction/pull/1)

##​ 변경 사유 

[SystemRules 라이브러리 Error 처리 PR](https://github.com/Jpub/SpringInAction/pull/1)에서 Chap_02의 예제 코드 실행이 안되어, 라이브러리 버전 업데이트를 했습니다. 

이전 PR에서 누락된 다른 예제 코드들의 `gradle.properties` 파일도 동일하게 적용했습니다. 